### PR TITLE
fix(orders): Enable customer fields for registered customers

### DIFF
--- a/frontend/src/components/OrderModal/ClientSection.jsx
+++ b/frontend/src/components/OrderModal/ClientSection.jsx
@@ -26,10 +26,10 @@ export function ClientSection({ permissions, formData, handleFormChange, clientT
                             </div>
                         )}
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-                            <FormField label="DNI" name="dni" type="text" value={formData.dni} onChange={handleFormChange} disabled={clientType === 'registrado'} required={clientType === 'nuevo'} />
-                            <FormField label="Nombre" name="first_name" type="text" value={formData.first_name} onChange={handleFormChange} disabled={clientType === 'registrado'} required={clientType === 'nuevo'} />
-                            <FormField label="Apellido" name="last_name" type="text" value={formData.last_name} onChange={handleFormChange} disabled={clientType === 'registrado'} required={clientType === 'nuevo'} />
-                            <FormField label="Teléfono" name="phone_number" type="tel" value={formData.phone_number} onChange={handleFormChange} disabled={clientType === 'registrado'} required={clientType === 'nuevo'} />
+                            <FormField label="DNI" name="dni" type="text" value={formData.dni} onChange={handleFormChange} required={clientType === 'nuevo'} />
+                            <FormField label="Nombre" name="first_name" type="text" value={formData.first_name} onChange={handleFormChange} required={clientType === 'nuevo'} />
+                            <FormField label="Apellido" name="last_name" type="text" value={formData.last_name} onChange={handleFormChange} required={clientType === 'nuevo'} />
+                            <FormField label="Teléfono" name="phone_number" type="tel" value={formData.phone_number} onChange={handleFormChange} required={clientType === 'nuevo'} />
                         </div>
                     </motion.div>
                 </AnimatePresence>


### PR DESCRIPTION
When an administrator creates an order for a registered customer, the form fields for the customer's data were being disabled. This prevented the administrator from proceeding with the order creation.

This change removes the `disabled` attribute from the customer data fields in the order creation modal. This allows administrators to see and edit the customer's data when creating an order for a registered customer, unblocking the order creation process.